### PR TITLE
Fix missing set_build_flags RPM macro

### DIFF
--- a/rpm_spec/libvchan.spec.in
+++ b/rpm_spec/libvchan.spec.in
@@ -45,7 +45,14 @@ The Qubes core libraries for installation inside a Qubes Dom0 and VM.
 %setup -q
 
 %build
-%set_build_flags
+# Macro set_build_flags is only in RPM v4.15 or in redhat-rpm-macros package
+%if 0%{?set_build_flags}
+  %set_build_flags
+%else
+  export CFLAGS="${CFLAGS:-%optflags}"
+  export CXXFLAGS="${CXXFLAGS:-%optflags}"
+  export FFLAGS="${FFLAGS:-%optflags}"
+%endif
 export LIBDIR=%{_libdir}
 export INCLUDEDIR=%{_includedir}
 make all


### PR DESCRIPTION
RPM macro set_build_flags is available only in RPM v4.15 or Fedora
specific redhat_rpm_macros package