### PR TITLE
Remove setting set_build_flags manually from spec file

### DIFF
--- a/rpm_spec/libvchan.spec.in
+++ b/rpm_spec/libvchan.spec.in
@@ -45,14 +45,7 @@ The Qubes core libraries for installation inside a Qubes Dom0 and VM.
 %setup -q
 
 %build
-# Macro set_build_flags is only in RPM v4.15 or in redhat-rpm-macros package
-%if 0%{?set_build_flags}
-  %set_build_flags
-%else
-  export CFLAGS="${CFLAGS:-%optflags}"
-  export CXXFLAGS="${CXXFLAGS:-%optflags}"
-  export FFLAGS="${FFLAGS:-%optflags}"
-%endif
+%{?set_build_flags}
 export LIBDIR=%{_libdir}
 export INCLUDEDIR=%{_includedir}
 make all


### PR DESCRIPTION
This macro is now globally defined during legacy/mock SUSE builds,
which is a much better way to make sure optimized flags are used.